### PR TITLE
BELAIR-180

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
-    minSdkVersion = 22
-    compileSdkVersion = 33
-    targetSdkVersion = 33
+    minSdkVersion = 23
+    compileSdkVersion = 34
+    targetSdkVersion = 34
     androidxActivityVersion = '1.7.0'
     androidxAppCompatVersion = '1.6.1'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/ios/App/fastlane/Fastfile
+++ b/ios/App/fastlane/Fastfile
@@ -9,10 +9,9 @@ platform :ios do
       env_vars: [
         'KEYCHAIN_PASSWORD',
         'MATCH_PASSWORD',
+        # 'MATCH_REPO_PASSWORD',
       ]
     )
-
-    setup_ci
 
     match(
       type: "appstore",


### PR DESCRIPTION
fix for previous commit to use  correct targetSDK version API level 34

also remove functionality to use/create custom keychain on ios runner